### PR TITLE
handle NoMethodError: undefined method `[]' for nil:NilClass

### DIFF
--- a/lib/aws/session_store/dynamo_db/locking/null.rb
+++ b/lib/aws/session_store/dynamo_db/locking/null.rb
@@ -32,6 +32,7 @@ module Aws::SessionStore::DynamoDB::Locking
 
     # @return [String] Session data.
     def extract_data(env, result = nil)
+      return nil unless result
       env['rack.initial_data'] = result[:item]["data"] if result[:item]
       unpack_data(result[:item]["data"]) if result[:item]
     end


### PR DESCRIPTION
This only handles the exception, does not solve the root of the problem. I'm hoping that is what https://github.com/Interfolio/aws-sessionstore-dynamodb-ruby/pull/2 is taking care of.

```
NoMethodError: undefined method `[]' for nil:NilClass

….5.1.1/lib/aws/session_store/dynamo_db/locking/
null.rb:  35:in `extract_data'
….5.1.1/lib/aws/session_store/dynamo_db/locking/
null.rb:  24:in `block in get_session_data'
….5.1.1/lib/aws/session_store/dynamo_db/locking/
base.rb:  58:in `handle_error'
….5.1.1/lib/aws/session_store/dynamo_db/locking/
null.rb:  22:in `get_session_data'
…1.1/lib/aws/session_store/dynamo_db/
rack_middleware.rb:  70:in `get_session'
…2.6.0/gems/rack-1.6.11/lib/rack/session/abstract/
id.rb: 266:in `load_session'
…2.6.0/gems/rack-1.6.11/lib/rack/session/abstract/
id.rb: 151:in `load!'
…2.6.0/gems/rack-1.6.11/lib/rack/session/abstract/
id.rb: 147:in `load_for_write!'
…2.6.0/gems/rack-1.6.11/lib/rack/session/abstract/
id.rb:  73:in `[]='
…mon-0.0.99.5/lib/by_committee_common/
authentication.rb:  58:in `block in populate_local_session'
…mon-0.0.99.5/lib/by_committee_common/
authentication.rb:  55:in `each_pair'
…mon-0.0.99.5/lib/by_committee_common/
authentication.rb:  55:in `populate_local_session'
…mon-0.0.99.5/lib/by_committee_common/
authentication.rb:  20:in `token_based_login'
…mon-0.0.99.5/lib/by_committee_common/
authentication.rb:   7:in `require_login'
…/gems/actionview-4.2.11.1/lib/action_view/
rendering.rb:  30:in `process'
…gems/flipper-0.16.2/lib/flipper/middleware/
memoizer.rb:  62:in `memoized_call'
…gems/flipper-0.16.2/lib/flipper/middleware/
memoizer.rb:  40:in `call'
…ed/bundle/ruby/2.6.0/gems/rack-1.6.11/lib/rack/
etag.rb:  24:in `call'
…ruby/2.6.0/gems/rack-1.6.11/lib/rack/
conditionalget.rb:  25:in `call'
…ed/bundle/ruby/2.6.0/gems/rack-1.6.11/lib/rack/
head.rb:  13:in `call'
…2.6.0/gems/rack-1.6.11/lib/rack/session/abstract/
id.rb: 225:in `context'
…2.6.0/gems/rack-1.6.11/lib/rack/session/abstract/
id.rb: 220:in `call'
…ms/request_store-1.3.1/lib/request_store/
middleware.rb:   9:in `call'
…ruby/2.6.0/gems/rack-1.6.11/lib/rack/
methodoverride.rb:  22:in `call'
…bundle/ruby/2.6.0/gems/rack-1.6.11/lib/rack/
runtime.rb:  18:in `call'
…undle/ruby/2.6.0/gems/rack-1.6.11/lib/rack/
sendfile.rb: 113:in `call'
…lib/phusion_passenger/rack/
thread_handler_extension.rb:  97:in `process_request'
…ib/phusion_passenger/request_handler/
thread_handler.rb: 149:in `accept_and_process_next_request'
…ib/phusion_passenger/request_handler/
thread_handler.rb: 110:in `main_loop'
…c/ruby_supportlib/phusion_passenger/
request_handler.rb: 415:in `block (3 levels) in start_threads'
…r-5.3.2/src/ruby_supportlib/phusion_passenger/
utils.rb: 113:in `block in create_thread_and_abort_on_exception'
```

It looks like the call to the locking/null.rb code is coming from here: https://github.com/Interfolio/aws-sessionstore-dynamodb-ruby/blob/master/lib/aws/session_store/dynamo_db/rack_middleware.rb#L70

I think we can safely return a nil, which would set data to nil, and then on the last line, `data || {}` would evaluate to the empty hash, which looks like something that is OK to do.